### PR TITLE
fead: add support for files with shebang

### DIFF
--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -29,11 +29,22 @@ module.exports = {
     },
     sectionOrder: [],
     collapse: true,
-    menu: {
-      'GitHub': {
-        href: `https://github.com/${packageJson.repository}`,
-        target: '_blank',
+    refLinks: [
+      {
+        title: 'View the package on Yarn',
+        url: `https://yarnpkg.com/package/${packageJson.name}`,
+        type: 'yarn',
       },
-    },
+      {
+        title: 'Go to the GitHub repository',
+        url: `https://github.com/${packageJson.repository}`,
+        type: 'github',
+      },
+      {
+        title: 'View the package on NPM',
+        url: `https://www.npmjs.com/package/${packageJson.name}`,
+        type: 'npm',
+      },
+    ],
   },
 };

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ module.exports = {
   },
   addModuleEntry: false,
   addPackageJson: true,
+  filesWithShebang: [],
 };
 ```
 
@@ -174,6 +175,14 @@ Whether or not to modify the project `package.json` and add a `module` property 
 Whether or not to add a `package.json` with `type` set to `module` on the `output` directory.
 
 > Default `true`
+
+#### .filesWithShebang
+
+The list of files that have a shebang, as the tool needs to remove it before transforming them in order to avoid issues with the parsers. The list are strings that will be converted on into `RegExp`s, so they can be a parts of the path, or expressions.
+
+For example, this project uses `src/bin.js`.
+
+> Default `[]`
 
 ## ⚙️ Development
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const { Jimpex } = require('jimpex');
 const ObjectUtils = require('wootils/shared/objectUtils');
 require('./homer0');
 
-// Become
+// Becomes
 
 import { Jimpex } from 'jimpex';
 import ObjectUtils from 'wootils/shared/objectUtils.js';
@@ -137,9 +137,11 @@ const options = {
 
 Now, when tool gets executed, it will perform the following change:
 
-```diff
-- const ObjectUtils = require('wootils/shared/objectUtils');
-+ import ObjectUtils from 'wootils/esm/shared/objectUtils.js';
+```js
+// From
+const ObjectUtils = require('wootils/shared/objectUtils');
+// To
+import ObjectUtils from 'wootils/esm/shared/objectUtils.js';
 ```
 
 > Default `[]`

--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ For example, this project uses `src/bin.js`.
 
 > Default `[]`
 
+## ES Modules
+
+Yes, if you want to use the tool as a library, the tool uses itself to generate a ESM version, so you can use the `/esm` path to access it:
+
+```js
+// commonjs
+const { getConfiguration } = require('cjs2esm');
+
+// ESM
+import { getConfiguration } from 'cjs2esm/esm';
+
+// #dogfooding
+```
 ## ⚙️ Development
 
 ### NPM/Yarn tasks

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "repository": "homer0/cjs2esm",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
+  "keywords": ["commonjs", "esmodules", "cjs", "esm", "es-modules"],
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.11.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint-staged": "^10.2.11",
     "semantic-release": "^17.1.1"
   },
+  "main": "src/index.js",
   "bin": {
     "cjs2esm": "./src/bin.js"
   },
@@ -51,6 +52,7 @@
     "*.js": "eslint"
   },
   "scripts": {
+    "prepublishOnly": "./utils/scripts/prepublishOnly",
     "test": "./utils/scripts/test",
     "lint": "./utils/scripts/lint",
     "lint:all": "./utils/scripts/lint-all",
@@ -58,6 +60,9 @@
     "todo": "./utils/scripts/todo"
   },
   "config": {
+    "cjs2esm": {
+      "filesWithShebang": ["src/bin.js"]
+    },
     "commitizen": {
       "path": "cz-conventional-changelog"
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jimple": "^1.5.0",
     "jsdoc": "^3.6.5",
     "jsdoc-ts-utils": "^1.0.0",
-    "docdash": "homer0/docdash#semver:^2.0.0",
+    "docdash": "homer0/docdash#semver:^2.1.0",
     "leasot": "^11.1.0",
     "lint-staged": "^10.2.11",
     "semantic-release": "^17.1.1"

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -96,7 +96,10 @@ const transform = (file, api, options) => {
      * function removes it, but that's needed for import statements: if they path doesn't
      * starts with `.`, it assumes that it's on `node_modules`.
      */
-    if (importPath.startsWith('./') && !replacement.startsWith('./')) {
+    if (
+      (importPath === '.' || importPath.startsWith('./')) &&
+      !replacement.startsWith('./')
+    ) {
       replacement = `./${replacement}`;
     }
 

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -39,6 +39,10 @@
  * and the file it points to was transformed.
  * @property {boolean} addPackageJson
  * Whether or not to add a `package.json` with `type` set to `module` on the `output` directory.
+ * @property {string[]} filesWithShebang
+ * The list of files that have a shebang, as the tool needs to remove it before transforming them
+ * in order to avoid issues with the parsers. The list are strings that will be converted on into
+ * `RegExp`s, so they can be a parts of the path, or expressions.
  */
 
 /**

--- a/utils/scripts/prepublishOnly
+++ b/utils/scripts/prepublishOnly
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+./src/bin.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,9 +268,9 @@
     js-tokens "^4.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.9.4":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.2.tgz#0882ab8a455df3065ea2dcb4c753b2460a24bead"
-  integrity sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==
+  version "7.11.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.3.tgz#9e1eae46738bcd08e23e867bab43e7b95299a8f9"
+  integrity sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.5"
@@ -1272,9 +1272,9 @@
     "@types/node" ">= 8"
 
 "@octokit/types@^5.0.0", "@octokit/types@^5.0.1", "@octokit/types@^5.2.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.3.0.tgz#f0d11e73887fdd06f34587d1fed1c2f597b1f752"
-  integrity sha512-qu6+YHQUl2IJkUBHzal68TNHTjQAgJG2l8C62f1lJ0FLsXhxuT2fe29Bwnl8UXSBof3TqBd92p+YYujzrkvWHQ==
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.4.0.tgz#25f2f8e24fec09214553168c41c06383c9d0f529"
+  integrity sha512-D/uotqF69M50OIlwMqgyIg9PuLT2daOiBAYF0P40I2ekFA2ESwwBY5dxZe/UhXdPvIbNKDzuZmQrO7rMpuFbcg==
   dependencies:
     "@types/node" ">= 8"
 
@@ -2917,9 +2917,9 @@ dir-glob@^3.0.0, dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-"docdash@homer0/docdash#semver:^2.0.0":
-  version "1.0.0"
-  resolved "https://codeload.github.com/homer0/docdash/tar.gz/dd3ae45bb02c0ce4c6922069af6cf0446d651e24"
+"docdash@homer0/docdash#semver:^2.1.0":
+  version "2.1.0"
+  resolved "https://codeload.github.com/homer0/docdash/tar.gz/90beee0333ff80305f2eedc8d549c0c13ffe7693"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -3235,9 +3235,9 @@ eslint-plugin-node@^11.1.0:
     semver "^6.1.0"
 
 eslint-plugin-sort-class-members@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.7.0.tgz#82b8bfd1bf4bf4a4766b67e816359085a49b1dc3"
-  integrity sha512-p9VeMf4lwJs4VJ9jDJRadXPklNGIdUYxeCLi0tjF3F83KNC6CfX+c3H2h0DQ2yLl3hgKf0j6s3wGpZUuRYToeA==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.8.0.tgz#92bcc0f88e9b9ebced01d45b631319f8485477f4"
+  integrity sha512-2DY2xgmcpHeTYgXrkAV2b7rQI1+6PhuAn/KWwU9ttiUF8V/V7dgu48Eru/67GfAPs+p6H6XDlaT2NjBpH2l+Qg==
 
 eslint-scope@^5.1.0:
   version "5.1.0"
@@ -3843,9 +3843,9 @@ get-stream@^4.0.0, get-stream@^4.1.0:
     pump "^3.0.0"
 
 get-stream@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
-  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
 
@@ -5216,9 +5216,9 @@ jsdoctypeparser@^9.0.0:
   integrity sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==
 
 jsdom@^16.2.2:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.3.0.tgz#75690b7dac36c67be49c336dcd7219bbbed0810c"
-  integrity sha512-zggeX5UuEknpdZzv15+MS1dPYG0J/TftiiNunOeNxSl3qr8Z6cIlQpN0IdJa44z9aFxZRIVqRncvEhQ7X5DtZg==
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.4.0.tgz#36005bde2d136f73eee1a830c6d45e55408edddb"
+  integrity sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==
   dependencies:
     abab "^2.0.3"
     acorn "^7.1.1"
@@ -6683,9 +6683,9 @@ onetime@^2.0.0:
     mimic-fn "^1.0.0"
 
 onetime@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.1.tgz#5c8016847b0d67fcedb7eef254751cfcdc7e9418"
-  integrity sha512-ZpZpjcJeugQfWsfyQlshVoowIIQ1qBGSVll4rfDq6JJVO//fesjoX808hXWfBjY+ROZgpKDI5TRSRBSoJiZ8eg==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
 


### PR DESCRIPTION
### What does this PR do?

A few fixes to follow up yesterday release:

1. Add missing keywords on the `package.json` ... because of reasons.
2. When I tried to transform the tool itself, I found out that it wasn't supporting `require('.')`; I fixed it so it will handle like it would handle `require('./')` (find the `package.json` or an _index_ file).
3. Another issue while transforming the tool itself: The `jscodeshift` parser explodes when a file has a shebang (`#!/usr/bin/env node` for example), so I added a new option (`filesWithShebang`) and the tool now removes it before the transformation and then adds it again once `jscodeshift` is done.
4. After fixing those previous bugs... the tool uses itself to create a ESM version on the `prepublishOnly` life cycle script.
5. I updated the `docdash` version with one that shows links to the registry.

The PR is tagged as "feature" because of the ESM version.

### How should it be tested manually?

```bash
npm run prepublishOnly
# or
yarn prepublishOnly
```
And of course...

```bash
npm test
# or
yarn test
```