### PR TITLE
Preserve leading comments

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -1,3 +1,6 @@
+/**
+ * Some comment about the function.
+ */
 const path = require('path');
 const fs = require('fs-extra');
 const { findFileSync, getAbsPathInfoSync } = require('./utils');
@@ -53,6 +56,8 @@ const transform = (file, api, options) => {
   const root = j(file.source);
   // Generate the list of expressions to ignore import statements.
   const ignoreListForExt = cjs2esm.extension.ignore.map((ignore) => new RegExp(ignore));
+
+  const originalFirstNode = root.find(j.Program).get('body', 0).node;
 
   // =================================================
   // Parse the import statements to add missing extensions.
@@ -122,6 +127,11 @@ const transform = (file, api, options) => {
 
         return j.importDeclaration(item.value.specifiers, j.literal(replacement));
       });
+  }
+
+  const newFirstNode = root.find(j.Program).get('body', 0).node;
+  if (newFirstNode !== originalFirstNode) {
+    newFirstNode.comments = originalFirstNode.comments;
   }
 
   // Regenerate the file code.

--- a/tests/transformer.test.js
+++ b/tests/transformer.test.js
@@ -41,10 +41,14 @@ describe('transformer', () => {
     ];
     let currentNodes = nodes.slice();
     const message = 'done';
+    const firstNode = 'first-node';
+    const programUtils = {
+      get: jest.fn(() => firstNode),
+    };
     const ast = {
       filter: jest.fn(),
       replaceWith: jest.fn(),
-      find: jest.fn(() => ast),
+      find: jest.fn((type) => (type === 'Program' ? programUtils : ast)),
       toSource: jest.fn(() => message),
     };
     ast.filter.mockImplementationOnce((fn) => {
@@ -61,6 +65,7 @@ describe('transformer', () => {
     });
     const jscodeshift = jest.fn(() => ast);
     jscodeshift.ImportDeclaration = 'ImportDeclaration';
+    jscodeshift.Program = 'Program';
     jscodeshift.importDeclaration = jest.fn((_, str) => str);
     jscodeshift.literal = jest.fn((str) => str);
     const api = { jscodeshift };
@@ -90,6 +95,110 @@ describe('transformer', () => {
       'specifier',
       './some/file.js',
     );
+    expect(ast.find).toHaveBeenCalledTimes(3);
+    expect(ast.find).toHaveBeenNthCalledWith(1, 'Program');
+    expect(ast.find).toHaveBeenNthCalledWith(2, 'ImportDeclaration');
+    expect(ast.find).toHaveBeenNthCalledWith(3, 'Program');
+    expect(programUtils.get).toHaveBeenCalledTimes(2);
+    expect(programUtils.get).toHaveBeenNthCalledWith(1, 'body', 0);
+    expect(programUtils.get).toHaveBeenNthCalledWith(2, 'body', 0);
+  });
+
+  it('should transform a file and preserve the leading comments', () => {
+    // Given
+    const file = {
+      path: path.join(cwd, 'index.js'),
+      source: 'magic',
+    };
+    const nodes = [
+      {
+        value: {
+          specifiers: 'specifier',
+          source: {
+            value: './some/file',
+          },
+        },
+      },
+      {
+        value: {
+          specifiers: 'specifier',
+          source: {
+            value: '~/some/weird/import/that/will/be/ignored',
+          },
+        },
+      },
+    ];
+    let currentNodes = nodes.slice();
+    const message = 'done';
+    const originalFirstNode = {
+      node: {
+        comments: 'original-first-node-comments',
+      },
+    };
+    const newFirstNode = {
+      node: {
+        comments: 'new-first-node-comments',
+      },
+    };
+    let getFirstNodeCount = 0;
+    const programUtils = {
+      get: jest.fn(() => {
+        const result = getFirstNodeCount ? newFirstNode : originalFirstNode;
+        getFirstNodeCount++;
+        return result;
+      }),
+    };
+    const ast = {
+      filter: jest.fn(),
+      replaceWith: jest.fn(),
+      find: jest.fn((type) => (type === 'Program' ? programUtils : ast)),
+      toSource: jest.fn(() => message),
+    };
+    ast.filter.mockImplementationOnce((fn) => {
+      currentNodes = currentNodes.filter(fn);
+      return ast;
+    });
+    ast.filter.mockImplementationOnce((fn) => {
+      currentNodes = currentNodes.filter(fn);
+      return ast;
+    });
+    ast.replaceWith.mockImplementationOnce((fn) => {
+      currentNodes = currentNodes.map(fn);
+      return ast;
+    });
+    const jscodeshift = jest.fn(() => ast);
+    jscodeshift.ImportDeclaration = 'ImportDeclaration';
+    jscodeshift.Program = 'Program';
+    jscodeshift.importDeclaration = jest.fn((_, str) => str);
+    jscodeshift.literal = jest.fn((str) => str);
+    const api = { jscodeshift };
+    const cjs2esm = {
+      extension: {
+        ignore: [],
+      },
+      modules: [],
+    };
+    const options = { cjs2esm };
+    utils.getAbsPathInfoSync.mockImplementationOnce(() => ({
+      isFile: true,
+      path: path.join(cwd, 'some', 'file.js'),
+    }));
+    let result = null;
+    // When
+    result = transformer(file, api, options);
+    // Then
+    expect(result).toBe(message);
+    expect(currentNodes).toEqual(['./some/file.js']);
+    expect(jscodeshift).toHaveBeenCalledTimes(1);
+    expect(jscodeshift).toHaveBeenCalledWith(file.source);
+    expect(utils.getAbsPathInfoSync).toHaveBeenCalledTimes(1);
+    expect(utils.getAbsPathInfoSync).toHaveBeenCalledWith(path.join(cwd, 'some', 'file'));
+    expect(jscodeshift.importDeclaration).toHaveBeenCalledTimes(1);
+    expect(jscodeshift.importDeclaration).toHaveBeenCalledWith(
+      'specifier',
+      './some/file.js',
+    );
+    expect(newFirstNode.comments).toBe(originalFirstNode.comments);
   });
 
   it('should transform a file that imports a directories', () => {
@@ -126,10 +235,14 @@ describe('transformer', () => {
     ];
     let currentNodes = nodes.slice();
     const message = 'done';
+    const firstNode = 'first-node';
+    const programUtils = {
+      get: jest.fn(() => firstNode),
+    };
     const ast = {
       filter: jest.fn(),
       replaceWith: jest.fn(),
-      find: jest.fn(() => ast),
+      find: jest.fn((type) => (type === 'Program' ? programUtils : ast)),
       toSource: jest.fn(() => message),
     };
     ast.filter.mockImplementationOnce((fn) => {
@@ -146,6 +259,7 @@ describe('transformer', () => {
     });
     const jscodeshift = jest.fn(() => ast);
     jscodeshift.ImportDeclaration = 'ImportDeclaration';
+    jscodeshift.Program = 'Program';
     jscodeshift.importDeclaration = jest.fn((_, str) => str);
     jscodeshift.literal = jest.fn((str) => str);
     const api = { jscodeshift };
@@ -231,10 +345,14 @@ describe('transformer', () => {
     ];
     let currentNodes = nodes.slice();
     const message = 'done';
+    const firstNode = 'first-node';
+    const programUtils = {
+      get: jest.fn(() => firstNode),
+    };
     const ast = {
       filter: jest.fn(),
       replaceWith: jest.fn(),
-      find: jest.fn(() => ast),
+      find: jest.fn((type) => (type === 'Program' ? programUtils : ast)),
       toSource: jest.fn(() => message),
     };
     ast.filter.mockImplementationOnce((fn) => {
@@ -251,6 +369,7 @@ describe('transformer', () => {
     });
     const jscodeshift = jest.fn(() => ast);
     jscodeshift.ImportDeclaration = 'ImportDeclaration';
+    jscodeshift.Program = 'Program';
     jscodeshift.importDeclaration = jest.fn((_, str) => str);
     jscodeshift.literal = jest.fn((str) => str);
     const api = { jscodeshift };
@@ -331,10 +450,14 @@ describe('transformer', () => {
       },
     ];
     let currentNodes = nodes.slice();
+    const firstNode = 'first-node';
+    const programUtils = {
+      get: jest.fn(() => firstNode),
+    };
     const ast = {
       filter: jest.fn(),
       replaceWith: jest.fn(),
-      find: jest.fn(() => ast),
+      find: jest.fn((type) => (type === 'Program' ? programUtils : ast)),
       toSource: jest.fn(),
     };
     ast.filter.mockImplementationOnce((fn) => {
@@ -351,6 +474,7 @@ describe('transformer', () => {
     });
     const jscodeshift = jest.fn(() => ast);
     jscodeshift.ImportDeclaration = 'ImportDeclaration';
+    jscodeshift.Program = 'Program';
     jscodeshift.importDeclaration = jest.fn((_, str) => str);
     jscodeshift.literal = jest.fn((str) => str);
     const api = { jscodeshift };
@@ -416,10 +540,14 @@ describe('transformer', () => {
     ];
     let currentNodes = nodes.slice();
     const message = 'done';
+    const firstNode = 'first-node';
+    const programUtils = {
+      get: jest.fn(() => firstNode),
+    };
     const ast = {
       filter: jest.fn(),
       replaceWith: jest.fn(),
-      find: jest.fn(() => ast),
+      find: jest.fn((type) => (type === 'Program' ? programUtils : ast)),
       toSource: jest.fn(() => message),
     };
     ast.filter.mockImplementationOnce((fn) => {
@@ -452,6 +580,7 @@ describe('transformer', () => {
     });
     const jscodeshift = jest.fn(() => ast);
     jscodeshift.ImportDeclaration = 'ImportDeclaration';
+    jscodeshift.Program = 'Program';
     jscodeshift.importDeclaration = jest.fn((_, str) => str);
     jscodeshift.literal = jest.fn((str) => str);
     const api = { jscodeshift };


### PR DESCRIPTION
### What does this PR do?

When transforming the files, since the first node is usually a `require`, the node gets replaced with an `import`, but since the `import` is being created as a new node, it didn't have any existing comment the original node had.

Thanks to [this useful guide](https://github.com/facebook/jscodeshift/blob/main/recipes/retain-first-comment.md), I was able to fix the issue, by copying the comments from the original node to the new one.

### How should it be tested manually?

Added a test to validate it, so...

```bash
npm test
# or
yarn test
```