### PR TITLE
Fix node_modules resolution and replacement path for modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -315,9 +315,12 @@ const transformOutput = async (files, options) => {
     shebangs = await removeShebangs(filesWithShebang);
   }
 
-  const fiveToSixCodeModPath = path.resolve('node_modules', '5to6-codemod', 'transforms');
+  const cjsTransformPath = require.resolve(
+    path.join('5to6-codemod', 'transforms', 'cjs.js'),
+  );
+  const fiveToSixCodeModPath = path.dirname(cjsTransformPath);
   const transformations = [
-    path.join(fiveToSixCodeModPath, 'cjs.js'),
+    cjsTransformPath,
     path.join(fiveToSixCodeModPath, 'exports.js'),
     path.join(fiveToSixCodeModPath, 'named-export-generation.js'),
     path.join(__dirname, 'transformer.js'),

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -117,8 +117,15 @@ const transform = (file, api, options) => {
       .replaceWith((item) => {
         const importPath = item.value.source.value;
         const info = cjs2esm.modules.find((mod) => importPath.startsWith(mod.name));
-        const find = info.find ? new RegExp(info.find) : new RegExp(`^${info.name}`);
-        const replacement = importPath.replace(find, info.path);
+        let replacement;
+        if (info.find) {
+          replacement = importPath.replace(new RegExp(info.find), info.path);
+        } else {
+          replacement = importPath.replace(
+            new RegExp(`^${info.name}($|\\/)`),
+            (match, endChar) => (endChar.endsWith('/') ? `${info.path}/` : info.path),
+          );
+        }
 
         return j.importDeclaration(item.value.specifiers, j.literal(replacement));
       });

--- a/tests/transformer.test.js
+++ b/tests/transformer.test.js
@@ -413,6 +413,22 @@ describe('transformer', () => {
           },
         },
       },
+      {
+        value: {
+          specifiers: 'specifier',
+          source: {
+            value: 'lodash',
+          },
+        },
+      },
+      {
+        value: {
+          specifiers: 'specifier',
+          source: {
+            value: 'lodash-es',
+          },
+        },
+      },
     ];
     let currentNodes = nodes.slice();
     const message = 'done';
@@ -422,10 +438,6 @@ describe('transformer', () => {
       find: jest.fn(() => ast),
       toSource: jest.fn(() => message),
     };
-    ast.filter.mockImplementationOnce((fn) => {
-      currentNodes = currentNodes.filter(fn);
-      return ast;
-    });
     ast.filter.mockImplementationOnce((fn) => {
       currentNodes = currentNodes.filter(fn);
       return ast;
@@ -469,6 +481,7 @@ describe('transformer', () => {
           find: 'par\\w+or',
           path: 'parserror/esm',
         },
+        { name: 'lodash', path: 'lodash-es' },
       ],
     };
     const options = { cjs2esm };
@@ -479,11 +492,18 @@ describe('transformer', () => {
       path: deepAssignPath,
     }));
     utils.getAbsPathInfoSync.mockImplementationOnce(() => null);
+    utils.getAbsPathInfoSync.mockImplementationOnce(() => null);
+    utils.getAbsPathInfoSync.mockImplementationOnce(() => null);
     let result = null;
     // When
     result = transformer(file, api, options);
     // Then
     expect(result).toBe(message);
-    expect(currentNodes).toEqual(['wootils/esm/shared/deepAssign.js', 'parserror/esm']);
+    expect(currentNodes).toEqual([
+      'wootils/esm/shared/deepAssign.js',
+      'parserror/esm',
+      'lodash-es',
+      'lodash-es',
+    ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

- When generating the path to the 5to6's transformations, the script was assuming a single `node_modules`. It now uses `require.resolve` to properly _resolve_ the paths. Credits to @wmertens since he first implemented it in #8.
- When replacing modules, the regular expression being generated, didn't include "limiters" (`/` or `$`), so if the project was using a module with a name that included the one you were replacing, it would get replaced too: #11 

### How should it be tested manually?

```bash
npm test
# or
yarn test
```