### PR TITLE
Add support to customize codemod path and transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ module.exports = {
   addModuleEntry: false,
   addPackageJson: true,
   filesWithShebang: [],
+  codemod: {
+    path: '',
+    files: ['cjs', 'exports', 'named-export-generation'],
+  },
 };
 ```
 
@@ -186,6 +190,55 @@ For example, this project uses `src/bin.js`.
 
 > Default `[]`
 
+#### .codemod
+
+Due to the `jscodeshift` and `5to6-codemod` projects not being updated quite often, it's not hard to run on scenarios in which your code is not compatible with the transformations, so this group of settings will allow you to run custom versions of the codemod, change the order fo the transformations, and even are your own.
+
+##### .path
+
+This is the path, relative to the working directory, in which the transformation files are located.
+
+> Default `''` // On runtime, it gets resolved to `5to6-codemod/transforms`
+
+##### .files
+
+These are the name of the files for the transformations, inside the `path` directory.
+
+The list can also be used to change the order of the default transformations, and it can also contain the `<cjs2esm>` special keyword, which references the tranformation file this package uses.
+
+For example:
+
+```json
+{
+  "files": [
+    "cjs",
+    "<cjs2esm>",
+    "named-export-generation",
+  ]
+}
+```
+
+With that, `exports` wouldn't be used, and the package transformation would run before `named-export-generation`.
+
+Local transformation files can also be specified, using path relatives to the working directory:
+
+```json
+{
+  "files": [
+    "cjs",
+    "<cjs2esm>",
+    "./my-custom-transformation",
+    "named-export-generation",
+  ]
+}
+```
+
+- ⚠️ If the list is empty, it will use the default value.
+- ⚠️ The `<cjs2esm>` cannot be used as the first item in the list.
+- ⚠️ The names can't contain the extension, and they need to be `.js` files.
+
+> Default `['cjs', 'exports', 'named-export-generation']`
+
 ## ES Modules
 
 Yes, if you want to use the tool as a library, the tool uses itself to generate a ESM version, so you can use the `/esm` path to access it:
@@ -270,3 +323,4 @@ Enjoy 🤘!
 
 > ~~Once `v14` becomes the oldest LTS, I'll archive this repository and deprecate the tool.~~
 > Node 12 now supports ESM without a flag, but there are still a lot of things that use CommonJS, and the fact that you can't `require` ESM makes things complicated, so I'm not sure yet when I'll deprecate the tool.
+> Update: 2022, and the interop is still a mess, so I'm not sure when I'll deprecate the tool.

--- a/src/index.js
+++ b/src/index.js
@@ -229,8 +229,8 @@ const copyFiles = async (input, output, useExtension, forceDirectory) => {
  * process explodes when a file has one.
  *
  * @param {CJS2ESMCopiedFile[]} files  The list of copied files with shebangs.
- * @returns {Object.<string, string>} The keys are the path to the copied files and the
- *                                    values the shebangs they had.
+ * @returns {Promise<Object.<string, string>>} The keys are the path to the copied files
+ *                                             and the values the shebangs they had.
  * @ignore
  */
 const removeShebangs = async (files) => {
@@ -392,7 +392,7 @@ const transformOutput = async (files, options) => {
  * will check for `index.mjs` and `index.js`.
  *
  * @param {string} absPath  The absolute path to the folder.
- * @returns {?string} If there's no `index`, the function will return `null`.
+ * @returns {Promise<?string>} If there's no `index`, the function will return `null`.
  * @ignore
  */
 const findFolderEntryPath = async (absPath) => {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -21,6 +21,17 @@
  */
 
 /**
+ * @typedef {Object} CJS2CodemodOptions
+ * @property {?string}   path   The path, relative to the cwd, to the transformations
+ *                              directory. By default, `5to6-codemod`, relative to this
+ *                              module.
+ * @property {?string[]} files  The list of transformations to use, without extension, as
+ *                              `.js` will be used`. If not defined, empty, or not an
+ *                              array, it will use the defaults: `cjs`, `exports` and
+ *                              `named-export-generation`.
+ */
+
+/**
  * @typedef {Object} CJS2ESMOptions
  * @property {string[]} input
  * The list of directories that should be transformed.
@@ -47,6 +58,8 @@
  * transforming them in order to avoid issues with the parsers. The list are strings that
  * will be converted on into `RegExp`s, so they can be a parts of the path, or
  * expressions.
+ * @property {?CJS2ESMOptions} codemod
+ * Options to customize integration with the codemod tool, for the transformations.
  */
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,7 +90,7 @@ const parseJSPath = (filepath) => {
  * Tries to find the extension for a file import path.
  *
  * @param {string} absPath  The generated absolute path for the file.
- * @returns {?string}
+ * @returns {Promise<?string>}
  * @ignore
  */
 const findFileExtension = async (absPath) => {
@@ -120,7 +120,7 @@ const findFileExtensionSync = (absPath) => {
  * case it's missing.
  *
  * @param {string} absPath  The absolute path for the resource.
- * @returns {?AbsPathInfo}
+ * @returns {Promise<?AbsPathInfo>}
  */
 const getAbsPathInfo = async (absPath) => {
   const info = parseJSPath(absPath);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -512,11 +512,11 @@ describe('index', () => {
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
-      // When
-      await transformOutput(files, options);
-      // Then
-      expect(Runner.run).toHaveBeenCalledTimes(4);
-      expect(Runner.run).toHaveBeenCalledWith(expect.any(String), [options.output], {
+      const expectedTransformations = ['cjs', 'exports', 'named-export-generation'].map(
+        (file) => require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
+      );
+      expectedTransformations.push(path.resolve('src', 'transformer.js'));
+      const expectedOptions = {
         verbose: 0,
         dry: false,
         print: false,
@@ -528,6 +528,127 @@ describe('index', () => {
         silent: true,
         parser: 'babel',
         cjs2esm: options,
+      };
+      // When
+      await transformOutput(files, options);
+      // Then
+      expectedTransformations.forEach((file, index) => {
+        expect(Runner.run).toHaveBeenNthCalledWith(
+          index + 1,
+          file,
+          [options.output],
+          expectedOptions,
+        );
+      });
+    });
+
+    it('should transform a list of files using a custom version of 5to6-codemod', async () => {
+      // Given
+      const files = [
+        {
+          to: 'index.js',
+        },
+        {
+          to: 'utils.js',
+        },
+      ];
+      const options = {
+        output: path.join(cwd, 'esm'),
+        codemod: {
+          path: 'custom-codemod',
+        },
+      };
+      const stats = {
+        timeElapsed: 25.09,
+        ok: files.length,
+        nochange: 0,
+      };
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      const expectedTransformations = ['cjs', 'exports', 'named-export-generation'].map(
+        (file) => path.resolve(options.codemod.path, `${file}.js`),
+      );
+      expectedTransformations.push(path.resolve('src', 'transformer.js'));
+      const expectedOptions = {
+        verbose: 0,
+        dry: false,
+        print: false,
+        babel: true,
+        extension: 'js',
+        ignorePattern: [],
+        ignoreConfig: [],
+        runInBand: false,
+        silent: true,
+        parser: 'babel',
+        cjs2esm: options,
+      };
+      // When
+      await transformOutput(files, options);
+      // Then
+      expectedTransformations.forEach((file, index) => {
+        expect(Runner.run).toHaveBeenNthCalledWith(
+          index + 1,
+          file,
+          [options.output],
+          expectedOptions,
+        );
+      });
+    });
+
+    it('should transform a list of files using a single transformation', async () => {
+      // Given
+      const files = [
+        {
+          to: 'index.js',
+        },
+        {
+          to: 'utils.js',
+        },
+      ];
+      const options = {
+        output: path.join(cwd, 'esm'),
+        codemod: {
+          files: ['exports'],
+        },
+      };
+      const stats = {
+        timeElapsed: 25.09,
+        ok: files.length,
+        nochange: 0,
+      };
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      const expectedTransformations = options.codemod.files.map((file) =>
+        require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
+      );
+      expectedTransformations.push(path.resolve('src', 'transformer.js'));
+      const expectedOptions = {
+        verbose: 0,
+        dry: false,
+        print: false,
+        babel: true,
+        extension: 'js',
+        ignorePattern: [],
+        ignoreConfig: [],
+        runInBand: false,
+        silent: true,
+        parser: 'babel',
+        cjs2esm: options,
+      };
+      // When
+      await transformOutput(files, options);
+      // Then
+      expectedTransformations.forEach((file, index) => {
+        expect(Runner.run).toHaveBeenNthCalledWith(
+          index + 1,
+          file,
+          [options.output],
+          expectedOptions,
+        );
       });
     });
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -13,6 +13,7 @@ const {
   updatePackageJSON,
   addPackageJSON,
   addErrorHandler,
+  CJS2ESM_TRANSFORMATION_NAME,
 } = require('../src');
 const utils = require('../src/utils');
 
@@ -649,6 +650,82 @@ describe('index', () => {
           [options.output],
           expectedOptions,
         );
+      });
+    });
+
+    it('should transform a list of files with a custom order of transformations', async () => {
+      // Given
+      const files = [
+        {
+          to: 'index.js',
+        },
+        {
+          to: 'utils.js',
+        },
+      ];
+      const options = {
+        output: path.join(cwd, 'esm'),
+        codemod: {
+          files: ['exports', CJS2ESM_TRANSFORMATION_NAME, 'named-export-generation'],
+        },
+      };
+      const stats = {
+        timeElapsed: 25.09,
+        ok: files.length,
+        nochange: 0,
+      };
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      const expectedTransformations = options.codemod.files.map((file) =>
+        file === CJS2ESM_TRANSFORMATION_NAME
+          ? path.resolve('src', 'transformer.js')
+          : require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
+      );
+      const expectedOptions = {
+        verbose: 0,
+        dry: false,
+        print: false,
+        babel: true,
+        extension: 'js',
+        ignorePattern: [],
+        ignoreConfig: [],
+        runInBand: false,
+        silent: true,
+        parser: 'babel',
+        cjs2esm: options,
+      };
+      // When
+      await transformOutput(files, options);
+      // Then
+      expectedTransformations.forEach((file, index) => {
+        expect(Runner.run).toHaveBeenNthCalledWith(
+          index + 1,
+          file,
+          [options.output],
+          expectedOptions,
+        );
+      });
+    });
+
+    it('should throw if the cjs2esm transformation is first in the list', () => {
+      // Given
+      const files = [
+        {
+          to: 'index.js',
+        },
+      ];
+      const options = {
+        output: path.join(cwd, 'esm'),
+        codemod: {
+          files: [CJS2ESM_TRANSFORMATION_NAME, 'named-export-generation'],
+        },
+      };
+      expect.assertions(1);
+      // When
+      return transformOutput(files, options).catch((error) => {
+        expect(error.message).toMatch(/cannot be the first one in the list/i);
       });
     });
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -513,10 +513,12 @@ describe('index', () => {
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
-      const expectedTransformations = ['cjs', 'exports', 'named-export-generation'].map(
-        (file) => require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
-      );
-      expectedTransformations.push(path.resolve('src', 'transformer.js'));
+      const expectedTransformations = [
+        ...['cjs', 'exports', 'named-export-generation'].map((file) =>
+          require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
+        ),
+        path.resolve('src', 'transformer.js'),
+      ];
       const expectedOptions = {
         verbose: 0,
         dry: false,
@@ -568,10 +570,12 @@ describe('index', () => {
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
-      const expectedTransformations = ['cjs', 'exports', 'named-export-generation'].map(
-        (file) => path.resolve(options.codemod.path, `${file}.js`),
-      );
-      expectedTransformations.push(path.resolve('src', 'transformer.js'));
+      const expectedTransformations = [
+        ...['cjs', 'exports', 'named-export-generation'].map((file) =>
+          path.resolve(options.codemod.path, `${file}.js`),
+        ),
+        path.resolve('src', 'transformer.js'),
+      ];
       const expectedOptions = {
         verbose: 0,
         dry: false,
@@ -623,10 +627,12 @@ describe('index', () => {
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
       Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
-      const expectedTransformations = options.codemod.files.map((file) =>
-        require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
-      );
-      expectedTransformations.push(path.resolve('src', 'transformer.js'));
+      const expectedTransformations = [
+        ...options.codemod.files.map((file) =>
+          require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
+        ),
+        path.resolve('src', 'transformer.js'),
+      ];
       const expectedOptions = {
         verbose: 0,
         dry: false,
@@ -683,6 +689,69 @@ describe('index', () => {
           ? path.resolve('src', 'transformer.js')
           : require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
       );
+      const expectedOptions = {
+        verbose: 0,
+        dry: false,
+        print: false,
+        babel: true,
+        extension: 'js',
+        ignorePattern: [],
+        ignoreConfig: [],
+        runInBand: false,
+        silent: true,
+        parser: 'babel',
+        cjs2esm: options,
+      };
+      // When
+      await transformOutput(files, options);
+      // Then
+      expectedTransformations.forEach((file, index) => {
+        expect(Runner.run).toHaveBeenNthCalledWith(
+          index + 1,
+          file,
+          [options.output],
+          expectedOptions,
+        );
+      });
+    });
+
+    it('should transform a list of files with custom transformations', async () => {
+      // Given
+      const files = [
+        {
+          to: 'index.js',
+        },
+        {
+          to: 'utils.js',
+        },
+      ];
+      const customTransformationBefore = './custom-transformation-before';
+      const customTransformationAfter = './custom-transformation-after';
+      const options = {
+        output: path.join(cwd, 'esm'),
+        codemod: {
+          files: [customTransformationBefore, 'exports', customTransformationAfter],
+        },
+      };
+      const stats = {
+        timeElapsed: 25.09,
+        ok: files.length,
+        nochange: 0,
+      };
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      Runner.run.mockImplementationOnce(() => Promise.resolve(stats));
+      const expectedTransformations = [
+        path.resolve(`${customTransformationBefore}.js`),
+        ...options.codemod.files
+          .filter((file) => !file.startsWith('.'))
+          .map((file) =>
+            require.resolve(path.join('5to6-codemod', 'transforms', `${file}.js`)),
+          ),
+        path.resolve(`${customTransformationAfter}.js`),
+        path.resolve('src', 'transformer.js'),
+      ];
       const expectedOptions = {
         verbose: 0,
         dry: false,


### PR DESCRIPTION
### What does this PR do?

New options were added to customize the integration with the codemod module. Read the `README` update for more context.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```

### TODOs
