### PR TITLE
Add option to ignore paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The tool has a lot of different settings you can change to customize how the imp
 ```js
 module.exports = {
   input: ['src'],
+  ignore: [],
   output: 'esm',
   forceDirectory: null,
   modules: [],
@@ -108,6 +109,12 @@ To modify the settings, you can...
 The list of directories that should be transformed.
 
 > Default `['src']`
+
+#### .ignore
+
+A list of expressions (strings that will be converted on `RegExp`) to specify files/paths that should be ignored.
+
+When a path is ignored, not only doesn't it get transformed, but it also doesn't get copied to the output directory.
 
 #### .output
 

--- a/src/bin.js
+++ b/src/bin.js
@@ -18,6 +18,7 @@ const {
     config.output,
     config.extension.use,
     config.forceDirectory,
+    config.ignore,
   );
   await transformOutput(files, config);
   if (config.addModuleEntry) {

--- a/src/index.js
+++ b/src/index.js
@@ -161,13 +161,25 @@ const findFiles = async (directory) => {
  * @param {boolean}         [forceDirectory=true]  If `false`, the directory itself won't
  *                                                 be copied,
  *                                                 just its contents.
+ * @param {string[]}        [ignore=[]]            A list of expressions for paths that
+ *                                                 should be ignored.
  * @returns {Promise<CJS2ESMCopiedFile[]>}
  * @ignore
  */
-const copyDirectory = async (directory, output, useExtension, forceDirectory = true) => {
+const copyDirectory = async (
+  directory,
+  output,
+  useExtension,
+  forceDirectory = true,
+  ignore = [],
+) => {
   const cwd = process.cwd();
   const extension = `.${useExtension}`;
   let contents = await findFiles(directory);
+  if (ignore.length) {
+    const ignoreExp = ignore.map((item) => new RegExp(item));
+    contents = contents.filter((item) => !ignoreExp.some((exp) => item.match(exp)));
+  }
   contents = await Promise.all(
     contents.map(async (item) => {
       let cleanPath = item.substr(cwd.length + 1);
@@ -207,9 +219,11 @@ const copyDirectory = async (directory, output, useExtension, forceDirectory = t
  *                                          instead of the directory itself; this
  *                                          parameter can be used to force it and always
  *                                          copy the directory.
+ * @param {?string[]}       ignore          A list of expressions for paths that should be
+ *                                          ignored.
  * @returns {Promise<CJS2ESMCopiedFile[]>}
  */
-const copyFiles = async (input, output, useExtension, forceDirectory) => {
+const copyFiles = async (input, output, useExtension, forceDirectory, ignore) => {
   let result;
   if (input.length === 1) {
     const [firstInput] = input;
@@ -218,10 +232,11 @@ const copyFiles = async (input, output, useExtension, forceDirectory) => {
       output,
       useExtension,
       forceDirectory === true,
+      ignore,
     );
   } else {
     result = await Promise.all(
-      input.map((item) => copyDirectory(item, output, useExtension)),
+      input.map((item) => copyDirectory(item, output, useExtension, undefined, ignore)),
     );
 
     result = result.reduce((acc, item) => [...acc, ...item], []);

--- a/tests/bin.test.js
+++ b/tests/bin.test.js
@@ -42,6 +42,7 @@ describe('bin', () => {
     const config = {
       input: 'some-input',
       output: 'some-output',
+      ignore: [],
       extension: {
         use: 'jsx',
       },
@@ -62,6 +63,7 @@ describe('bin', () => {
       config.output,
       config.extension.use,
       config.forceDirectory,
+      config.ignore,
     );
     expect(fns.transformOutput).toHaveBeenCalledTimes(1);
     expect(fns.transformOutput).toHaveBeenCalledWith(files, config);
@@ -77,6 +79,7 @@ describe('bin', () => {
         use: 'jsx',
       },
       forceDirectory: 'maybe',
+      ignore: [],
       addModuleEntry: true,
     };
     const files = ['file-a.js', 'file-b.mjs'];
@@ -94,6 +97,7 @@ describe('bin', () => {
       config.output,
       config.extension.use,
       config.forceDirectory,
+      config.ignore,
     );
     expect(fns.transformOutput).toHaveBeenCalledTimes(1);
     expect(fns.transformOutput).toHaveBeenCalledWith(files, config);
@@ -109,6 +113,7 @@ describe('bin', () => {
         use: 'jsx',
       },
       forceDirectory: 'maybe',
+      ignore: [],
       addPackageJson: true,
     };
     const files = ['file-a.js', 'file-b.mjs'];
@@ -126,6 +131,7 @@ describe('bin', () => {
       config.output,
       config.extension.use,
       config.forceDirectory,
+      config.ignore,
     );
     expect(fns.transformOutput).toHaveBeenCalledTimes(1);
     expect(fns.transformOutput).toHaveBeenCalledWith(files, config);


### PR DESCRIPTION
### What does this PR do?

This was requested in #8: what happens if there's a `node_modules` inside the input directory? Now you can use `ignore` to specify `node_modules`... or whatever expression you want to ignore.

The files/directories that match the expression(s) will not be copied to the output directory, which also means that they won't be even considered for transformation.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```